### PR TITLE
fix: added a comment response if contributor assigns self to already assigned issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Message to prospective contributor'
     required: false
     default: ''
+  issueCurrentlyAssignedMessage:
+    description: 'Message to contributors if issue is already assigned'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -29,14 +33,18 @@ runs:
             echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
             echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
             curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
+            echo "What is the input message?"
             if [[ ! -z $INPUT_MESSAGE ]]; then
-              jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
+              jq -n -r --arg body "$ISSUE_CURRENTLY_ASSIGNED_MESSAGE" '{body: $body}' > payload.json
               curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
             fi
           else
             echo "This issue is currently assigned to a different user"
+            jq -n -r --arg body "$ISSUE_CURRENTLY_ASSIGNED_MESSAGE" '{body: $body}' > payload.json
+            curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
           fi
         fi
       shell: bash
       env:
         INPUT_MESSAGE: "${{ inputs.message }}"
+        ISSUE_CURRENTLY_ASSIGNED_MESSAGE: "${{ inputs.issueCurrentlyAssignedMessage }}"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   issueCurrentlyAssignedMessage:
     description: 'Message to contributors if issue is already assigned'
     required: false
-    default: 'This issue is currently assigned to another contributor.'
+    default: 'The issue you are trying to assign to yourself is already assigned.'
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,10 @@ runs:
             fi
           else
             echo "This issue is currently assigned to a different user"
+            if [[ ! -z $ISSUE_CURRENTLY_ASSIGNED_MESSAGE ]]; then
             jq -n -r --arg body "$ISSUE_CURRENTLY_ASSIGNED_MESSAGE" '{body: $body}' > payload.json
             curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
+            fi
           fi
         fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   issueCurrentlyAssignedMessage:
     description: 'Message to contributors if issue is already assigned'
     required: false
-    default: ''
+    default: 'This issue is currently assigned to another contributor.'
 
 runs:
   using: "composite"
@@ -35,7 +35,7 @@ runs:
             curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
             echo "What is the input message?"
             if [[ ! -z $INPUT_MESSAGE ]]; then
-              jq -n -r --arg body "$ISSUE_CURRENTLY_ASSIGNED_MESSAGE" '{body: $body}' > payload.json
+              jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
               curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
             fi
           else

--- a/action.yml
+++ b/action.yml
@@ -29,11 +29,10 @@ runs:
 
         if [[ $BODY == *".take"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
-            echo "$ISSUE_CURRENTLY_ASSIGNED"
+            echo "Is issue currently assigned: $ISSUE_CURRENTLY_ASSIGNED"
             echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
             echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
             curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
-            echo "What is the input message?"
             if [[ ! -z $INPUT_MESSAGE ]]; then
               jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
               curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

<!-- Please do not leave this blank -->

When a contributor assigns themselves to an already assigned ticket, a comment will be made to let the contributor know that the issue is already assigned and you may need to take other actions. The contents of the message have to be defined in the repo's workflow file. 

I added the content of this comment for the Open Sauced community in this PR: https://github.com/open-sauced/hot/pull/77

**(Will this affect other people who are using this action?)** 

## Related Tickets & Documents
Fixes #7 
Related PR in Open Sauced community, which defines the content of this comment:  https://github.com/open-sauced/hot/pull/77

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
This is the secondary comment

![image](https://user-images.githubusercontent.com/22990146/148820224-0205d800-63f0-4e32-87e5-c9cecd6ac8fb.png)



## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [ ] 📜 contributing.md
- [ ] 📓 docs
- [ ] 📕 storybook
- [x] 🙅 no documentation needed




<!-- note: PRs with deletes sections will be marked invalid -->

