### PR TITLE
Allow user to specify activation string

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 This GitHub Action lets a prospective contributor assign themselves to an issue, and optionally leaves a comment on the issue.
 
-- `confirmation_message`<br />The message to display to the user once they have assigned themselves to an issue.
-- `activation_message`<br />The string that take action will search for in the comment body to activate the action.
+- `message`<br />The message to display to the user once they have assigned themselves to an issue.
+- `trigger`<br />The string that take action will search for in the comment body to activate the action.
 
 ## Setup
 
@@ -28,6 +28,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
-        confirmation_message: Thanks for taking this issue! Let us know if you have any questions!
-        activation_message: .take
+        message: Thanks for taking this issue! Let us know if you have any questions!
+        trigger: .take
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 This GitHub Action lets a prospective contributor assign themselves to an issue, and optionally leaves a comment on the issue.
 
 
+
 ## Setup
 
 This GitHub Action requires a GITHUB_TOKEN and can be optionally configured with a message to the prospective contributor.
@@ -26,5 +27,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
-        message: Thanks for taking this issue! Let us know if you have any questions!
+        confirmation_message: Thanks for taking this issue! Let us know if you have any questions!
+        activation_message: .take
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 This GitHub Action lets a prospective contributor assign themselves to an issue, and optionally leaves a comment on the issue.
 
-
+- `confirmation_message`<br />The message to display to the user once they have assigned themselves to an issue.
+- `activation_message`<br />The string that take action will search for in the comment body to activate the action.
 
 ## Setup
 

--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,14 @@ runs:
         ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
         ISSUE_CURRENTLY_ASSIGNED=`echo $ISSUE_JSON | jq '.assignees | length == 0'`
 
-        if [[ $BODY == *"$INPUT_ACTIVATION_MESSAGE"* ]]; then
+        if [[ $BODY == *"$INPUT_TRIGGER"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
             echo "Is issue currently assigned: $ISSUE_CURRENTLY_ASSIGNED"
             echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
             echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
             curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
-            if [[ ! -z $INPUT_CONFIRMATION_MESSAGE ]]; then
-              jq -n -r --arg body "$INPUT_CONFIRMATION_MESSAGE" '{body: $body}' > payload.json
+            if [[ ! -z $INPUT_MESSAGE ]]; then
+              jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
               curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
             fi
           else
@@ -47,6 +47,6 @@ runs:
         fi
       shell: bash
       env:
-        INPUT_CONFIRMATION_MESSAGE: "${{ inputs.message }}"
-        INPUT_ACTIVATION_MESSAGE: "${{ inputs.activation_message }}"
+        INPUT_MESSAGE: "${{ inputs.message }}"
+        INPUT_TRIGGER: "${{ inputs.trigger }}"
         ISSUE_CURRENTLY_ASSIGNED_MESSAGE: "${{ inputs.issueCurrentlyAssignedMessage }}"

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Message to contributors if issue is already assigned'
     required: false
     default: 'The issue you are trying to assign to yourself is already assigned.'
+  trigger:
+    description: 'The string that triggers the action'
+    required: false
+    default: '.take'
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,14 @@ runs:
         ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
         ISSUE_CURRENTLY_ASSIGNED=`echo $ISSUE_JSON | jq '.assignees | length == 0'`
 
-        if [[ $BODY == *".take"* ]]; then
+        if [[ $BODY == *"$INPUT_ACTIVATION_MESSAGE"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
             echo "Is issue currently assigned: $ISSUE_CURRENTLY_ASSIGNED"
             echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
             echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
             curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
-            if [[ ! -z $INPUT_MESSAGE ]]; then
-              jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
+            if [[ ! -z $INPUT_CONFIRMATION_MESSAGE ]]; then
+              jq -n -r --arg body "$INPUT_CONFIRMATION_MESSAGE" '{body: $body}' > payload.json
               curl -X POST -H "Authorization: token $GITHUB_TOKEN" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
             fi
           else
@@ -47,5 +47,6 @@ runs:
         fi
       shell: bash
       env:
-        INPUT_MESSAGE: "${{ inputs.message }}"
+        INPUT_CONFIRMATION_MESSAGE: "${{ inputs.confirmation_message }}"
+        INPUT_ACTIVATION_MESSAGE: "${{ inputs.activation_message }}"
         ISSUE_CURRENTLY_ASSIGNED_MESSAGE: "${{ inputs.issueCurrentlyAssignedMessage }}"

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,6 @@ runs:
         fi
       shell: bash
       env:
-        INPUT_CONFIRMATION_MESSAGE: "${{ inputs.confirmation_message }}"
+        INPUT_CONFIRMATION_MESSAGE: "${{ inputs.message }}"
         INPUT_ACTIVATION_MESSAGE: "${{ inputs.activation_message }}"
         ISSUE_CURRENTLY_ASSIGNED_MESSAGE: "${{ inputs.issueCurrentlyAssignedMessage }}"


### PR DESCRIPTION
Adds a new `activation_message` variable to allow users to specify which activation string they want take-action to trigger on.

Allows user to specify an activation string that aligns with other platforms. For example, Slack and Discord use / to denote a command, so user can specify `/take` or `/mine` if they prefer.

Provides back compatible defaults so as not to break existing installations.

Resolves #9 