### PR TITLE
feat: add support for blocking labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 This GitHub Action lets a prospective contributor assign themselves to an issue, and optionally leaves a comment on the issue.
 
 - `message`<br />The message to display to the user once they have assigned themselves to an issue.
+- `blockingLabels`<br />A comma-separated list of labels that will prevent the action from running if they are present on the issue.
+- `blockingLabelsMessage`<br />The message to display to the user if the issue has a blocking label.
 - `trigger`<br />The string that take action will search for in the comment body to activate the action.
 
 ## Setup
@@ -17,15 +19,15 @@ The Action must be given a PAT with permission to write to Issues in the `token`
 The easiest way is to use the built-in `${{ secrets.GITHUB_TOKEN }}` for authentication (as per the example below), but you'll need to ensure you've appropriately set [the permissions for the GitHub Token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) so that your workflow can update Issues.
 
 To do this, follow the instructions in this doc: [Managing GitHub Actions Permissions for your repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository).
-  
-You can also configure `message:` below to be a custom message. Note that you cannot use words like `it's` or `let's` as the apostrophe messes with the syntax. You can use emojis, however you'll need to copy and paste the emoji directly like `❤️` instead of `:heart:` as the semi-colons ruin the syntax. 
+
+You can also configure `message:` below to be a custom message. Note that you cannot use words like `it's` or `let's` as the apostrophe messes with the syntax. You can use emojis, however you'll need to copy and paste the emoji directly like `❤️` instead of `:heart:` as the semi-colons ruin the syntax.
 
 ### Example Workflow:
 
 ```yaml
-# .github/workflows/take.yml 
+# .github/workflows/take.yml
 name: Assign issue to contributor
-on: 
+on:
   issue_comment:
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         LOGIN="$(jq '.comment.user.login' $GITHUB_EVENT_PATH | tr -d \")"
         REPO="$(jq '.repository.full_name' $GITHUB_EVENT_PATH | tr -d \")"
         ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
-        ISSUE_LABELS="$(jq '.issue.labels' $GITHUB_EVENT_PATH)"
+        ISSUE_LABELS="$(jq '.issue.labels[].name' $GITHUB_EVENT_PATH)"
         ISSUE_CURRENTLY_ASSIGNED=`echo $ISSUE_JSON | jq '.assignees | length == 0'`
 
         if [[ $BODY == *"$INPUT_TRIGGER"* ]]; then

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,17 @@ inputs:
     description: 'Message to contributors if issue is already assigned'
     required: false
     default: 'The issue you are trying to assign to yourself is already assigned.'
+
+  blockingLabels:
+    description: 'Optional labels that are on an issue that block an issue from being assigned by the trigger.'
+    required: false
+    default: ''
+
+  blockingLabelsMessage:
+    description: 'Message to contributors if issue is blocked by a label'
+    required: false
+    default: 'The issue you are trying to assign to yourself is blocked by a one or more labels on the issue.'
+
   trigger:
     description: 'The string that triggers the action'
     required: false
@@ -54,6 +65,8 @@ runs:
       shell: bash
       env:
         INPUT_MESSAGE: "${{ inputs.message }}"
+        RAW_BLOCKING_LABELS: "${{ inputs.blockingLabels }}"
+        BLOCKING_LABELS_MESSAGE: "${{ inputs.blockingLabelsMessage }}"
         INPUT_TRIGGER: "${{ inputs.trigger }}"
         ISSUE_CURRENTLY_ASSIGNED_MESSAGE: "${{ inputs.issueCurrentlyAssignedMessage }}"
         GITHUB_PAT: "${{ inputs.token }}"

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,12 @@ runs:
 
         if [[ $BODY == *"$INPUT_TRIGGER"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
-            BLOCKING_LABELS=$(echo "$RAW_BLOCKING_LABELS" | jq -n --arg str "$RAW_BLOCKING_LABELS" '$str | split(",")')
+            if [ -n "$RAW_BLOCKING_LABELS" ]; then
+                BLOCKING_LABELS=$(echo "$RAW_BLOCKING_LABELS" | jq -n --arg str "$RAW_BLOCKING_LABELS" '$str | split(",")')
+            else
+                # In case no blocking labels are set, set an empty array
+                BLOCKING_LABELS=()
+            fi
 
             echo "Issue labels: $ISSUE_LABELS"
             echo "Blocking labels: $BLOCKING_LABELS"

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,7 @@ runs:
             echo "Issue labels: $ISSUE_LABELS"
             echo "Blocking labels: $BLOCKING_LABELS"
 
+            # See if at least one label on the issue is in the list of blocking labels
             blocking_label_found=$(jq -n --argjson ISSUE_LABELS "$ISSUE_LABELS" --argjson BLOCKING_LABELS "$BLOCKING_LABELS" '$ISSUE_LABELS as $il | $BLOCKING_LABELS as $bl | any($il[]; . as $i | any($bl[]; . == $i))')
 
             echo "blocking label found: $blocking_label_found"
@@ -61,11 +62,13 @@ runs:
               echo "Issue contains one or more blocking labels: $BLOCKING_LABELS"
               echo "Unable to assign issue $ISSUE_NUMBER to $LOGIN"
 
+              # Post a comment on the issue that there are blocking labels on the issue preventing it from being assigned
               if [[ ! -z $BLOCKING_LABELS_MESSAGE ]]; then
                 jq -n -r --arg body "$BLOCKING_LABELS_MESSAGE" '{body: $body}' > payload.json
                 curl -X POST -H "Authorization: bearer $GITHUB_PAT" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
               fi
             else
+              # Assign the issue to the user
               echo "Is issue currently assigned: $ISSUE_CURRENTLY_ASSIGNED"
               echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
               echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"

--- a/action.yml
+++ b/action.yml
@@ -42,17 +42,47 @@ runs:
         LOGIN="$(jq '.comment.user.login' $GITHUB_EVENT_PATH | tr -d \")"
         REPO="$(jq '.repository.full_name' $GITHUB_EVENT_PATH | tr -d \")"
         ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
+        ISSUE_LABELS="$(jq '.issue.labels' $GITHUB_EVENT_PATH)"
         ISSUE_CURRENTLY_ASSIGNED=`echo $ISSUE_JSON | jq '.assignees | length == 0'`
 
         if [[ $BODY == *"$INPUT_TRIGGER"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
-            echo "Is issue currently assigned: $ISSUE_CURRENTLY_ASSIGNED"
-            echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
-            echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
-            curl -H "Authorization: bearer $GITHUB_PAT" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
-            if [[ ! -z $INPUT_MESSAGE ]]; then
-              jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
-              curl -X POST -H "Authorization: bearer $GITHUB_PAT" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
+            BLOCKING_LABELS=$(echo "$RAW_BLOCKING_LABELS" | jq -n --arg str "$RAW_BLOCKING_LABELS" '$str | split(",")')
+
+            blocking_label_found=false
+
+            # See if any of the issue labels match at least one blocking label
+            for issue_label in "${ISSUE_LABELS[@]}"; do
+                label_exists=false
+                for blocking_label in "${BLOCKING_LABELS[@]}"; do
+                    if [ "$issue_label" == "$blocking_label" ]; then
+                        label_exists=true
+                        break
+                    fi
+                done
+
+                if [ "$value_exists" == true ]; then
+                    blocking_label_found=true
+                fi
+            done
+
+            if [ "$blocking_label_found" == true ]; then
+              echo "Issue contains one or more blocking labels: $BLOCKING_LABELS"
+              echo "Unable to assign issue $ISSUE_NUMBER to $LOGIN"
+
+              if [[ ! -z $BLOCKING_LABELS_MESSAGE ]]; then
+                jq -n -r --arg body "$BLOCKING_LABELS_MESSAGE" '{body: $body}' > payload.json
+                curl -X POST -H "Authorization: bearer $GITHUB_PAT" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
+              fi
+            else
+              echo "Is issue currently assigned: $ISSUE_CURRENTLY_ASSIGNED"
+              echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
+              echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
+              curl -H "Authorization: bearer $GITHUB_PAT" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
+              if [[ ! -z $INPUT_MESSAGE ]]; then
+                jq -n -r --arg body "$INPUT_MESSAGE" '{body: $body}' > payload.json
+                curl -X POST -H "Authorization: bearer $GITHUB_PAT" --data @payload.json https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
+              fi
             fi
           else
             echo "This issue is currently assigned to a different user"

--- a/action.yml
+++ b/action.yml
@@ -42,29 +42,20 @@ runs:
         LOGIN="$(jq '.comment.user.login' $GITHUB_EVENT_PATH | tr -d \")"
         REPO="$(jq '.repository.full_name' $GITHUB_EVENT_PATH | tr -d \")"
         ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
-        ISSUE_LABELS="$(jq '.issue.labels[].name' $GITHUB_EVENT_PATH)"
+        ISSUE_LABELS="$(jq -r '.issue.labels[].name' $GITHUB_EVENT_PATH)"
+        ISSUE_LABELS=$(echo "$ISSUE_LABELS" | jq -n --arg str "$ISSUE_LABELS" '$str | split("\n")')
         ISSUE_CURRENTLY_ASSIGNED=`echo $ISSUE_JSON | jq '.assignees | length == 0'`
 
         if [[ $BODY == *"$INPUT_TRIGGER"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
             BLOCKING_LABELS=$(echo "$RAW_BLOCKING_LABELS" | jq -n --arg str "$RAW_BLOCKING_LABELS" '$str | split(",")')
 
-            blocking_label_found=false
+            echo "Issue labels: $ISSUE_LABELS"
+            echo "Blocking labels: $BLOCKING_LABELS"
 
-            # See if any of the issue labels match at least one blocking label
-            for issue_label in "${ISSUE_LABELS[@]}"; do
-                label_exists=false
-                for blocking_label in "${BLOCKING_LABELS[@]}"; do
-                    if [ "$issue_label" == "$blocking_label" ]; then
-                        label_exists=true
-                        break
-                    fi
-                done
+            blocking_label_found=$(jq -n --argjson ISSUE_LABELS "$ISSUE_LABELS" --argjson BLOCKING_LABELS "$BLOCKING_LABELS" '$ISSUE_LABELS as $il | $BLOCKING_LABELS as $bl | any($il[]; . as $i | any($bl[]; . == $i))')
 
-                if [ "$value_exists" == true ]; then
-                    blocking_label_found=true
-                fi
-            done
+            echo "blocking label found: $blocking_label_found"
 
             if [ "$blocking_label_found" == true ]; then
               echo "Issue contains one or more blocking labels: $BLOCKING_LABELS"


### PR DESCRIPTION
Adds support for blocking labels. Adding blocking labels is optional, so the GitHub action works as it did previously if no blocking labels are configured.

Existing scenarios:
- There are no blocking labels on an issue:
    - The user can be assigned the issue assuming it isn't already assigned. See https://github.com/nickytonline/test-take-action/actions/runs/6566343428/job/17837978699

    - The user cannot be assigned the issue if someone is already assigned. See https://github.com/nickytonline/test-take-action/actions/runs/6566879299/job/17838484505

- There is a blocking label on an issue:
    - The user cannot be assigned. See https://github.com/nickytonline/test-take-action/actions/runs/6566973419/job/17838795429
- There is more than one blocking label on an issue:
    - The user cannot be assigned. See https://github.com/nickytonline/test-take-action/actions/runs/6566887793/job/17838515063

Sample workflow for this workflow in a repository with blocking labels enabled

```diff
name: "Assign issues with .take"

on:
  issue_comment:
    types:
      - created
      - edited

jobs:
  take-issue:
    name: Disable take issue
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - name: take an issue
        uses: bdougie/take-action@main
        with:
          issueCurrentlyAssignedMessage: Thanks for being interested in this issue. It looks like this ticket is already assigned to a contributor.
          token: ${{ secrets.GITHUB_TOKEN }}
+          blockingLabels: needs triage,blocked
```

I'm pretty sure this is unrelated as I didn't change anything for how the GitHub API calls work, but I think I have the action misconfigured as I get this error when trying to use the API. Not sure why it's not finding my `secrets.GITHUB_TOKEN`

`"message": "Resource not accessible by integration",`

Closes #20

<img src="https://media1.giphy.com/media/3o72FiRWbinrq1YKti/giphy-downsized-medium.gif"/>