### PR TITLE
fix: removed unnecessary guard for no blocking labels

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,12 +48,7 @@ runs:
 
         if [[ $BODY == *"$INPUT_TRIGGER"* ]]; then
           if [[ "$ISSUE_CURRENTLY_ASSIGNED" == true ]]; then
-            if [ -n "$RAW_BLOCKING_LABELS" ]; then
-                BLOCKING_LABELS=$(echo "$RAW_BLOCKING_LABELS" | jq -n --arg str "$RAW_BLOCKING_LABELS" '$str | split(",")')
-            else
-                # In case no blocking labels are set, set an empty array
-                BLOCKING_LABELS=()
-            fi
+            BLOCKING_LABELS=$(echo "$RAW_BLOCKING_LABELS" | jq -n --arg str "$RAW_BLOCKING_LABELS" '$str | split(",")')
 
             echo "Issue labels: $ISSUE_LABELS"
             echo "Blocking labels: $BLOCKING_LABELS"


### PR DESCRIPTION
I added a guard to check if the blocking labels were empty. It defaults to an empty string which `jq` can handle converting to an empty array, so the guard is unnecessary and actually breaks the action if no blocking labels are specified.

I've removed the guard and you can see it working as intended when no blocking labels are specified.

See these two test issues when there are no blocking labels:
- An issue with no labels: https://github.com/nickytonline/test-take-action/issues/4
    - Related action runs:
        -  https://github.com/nickytonline/test-take-action/actions/runs/6573969335
        - https://github.com/nickytonline/test-take-action/actions/runs/6574025191
- An issue at least one label: https://github.com/nickytonline/test-take-action/issues/3
    - Related action runs:
        -  https://github.com/nickytonline/test-take-action/actions/runs/6574100620/job/17858453915

<img src="https://media4.giphy.com/media/BsQAVgY6ksvIY/giphy.gif"/>